### PR TITLE
Fix module name generation and other fixes

### DIFF
--- a/src/main/java/cpw/mods/jarhandling/JarMetadata.java
+++ b/src/main/java/cpw/mods/jarhandling/JarMetadata.java
@@ -14,7 +14,7 @@ public interface JarMetadata {
     String version();
     ModuleDescriptor descriptor();
     // ALL from jdk.internal.module.ModulePath.java
-    Pattern DASH_VERSION = Pattern.compile("-(\\d+(\\.|$))");
+    Pattern DASH_VERSION = Pattern.compile("-([.\\d]+)");
     Pattern NON_ALPHANUM = Pattern.compile("[^A-Za-z0-9]");
     Pattern REPEATING_DOTS = Pattern.compile("(\\.)(\\1)+");
     Pattern LEADING_DOTS = Pattern.compile("^\\.");
@@ -43,7 +43,7 @@ public interface JarMetadata {
         var mat = DASH_VERSION.matcher(fn);
         if (mat.find()) {
             var ver = ModuleDescriptor.Version.parse(fn.substring(mat.start() + 1)).toString();
-            var name = fn.substring(0, mat.start());
+            var name = mat.replaceAll("");
             return new SimpleJarMetadata(cleanModuleName(name), ver, pkgs, providers);
         } else {
             return new SimpleJarMetadata(cleanModuleName(fn), null, pkgs, providers);

--- a/src/main/java/cpw/mods/jarhandling/SecureJar.java
+++ b/src/main/java/cpw/mods/jarhandling/SecureJar.java
@@ -20,8 +20,6 @@ import java.util.jar.Manifest;
 public interface SecureJar {
     Path getPrimaryPath();
 
-    BiPredicate<String, String> getPathFilter();
-
     Optional<URI> findFile(String name);
 
     Manifest getManifest();

--- a/src/main/java/cpw/mods/jarhandling/SecureJar.java
+++ b/src/main/java/cpw/mods/jarhandling/SecureJar.java
@@ -37,11 +37,19 @@ public interface SecureJar {
     boolean hasSecurityData();
 
     static SecureJar from(final Path... paths) {
-        return from(Manifest::new, jar -> JarMetadata.from(jar, paths), paths);
+        return from(jar -> JarMetadata.from(jar, paths), paths);
     }
 
     static SecureJar from(BiPredicate<String, String> filter, final Path... paths) {
-        return from(Manifest::new, jar->JarMetadata.from(jar, paths), filter, paths);
+        return from(jar->JarMetadata.from(jar, paths), filter, paths);
+    }
+
+    static SecureJar from(Function<SecureJar, JarMetadata> metadataSupplier, final Path... paths) {
+        return from(Manifest::new, metadataSupplier, paths);
+    }
+
+    static SecureJar from(Function<SecureJar, JarMetadata> metadataSupplier, BiPredicate<String, String> filter, final Path... paths) {
+        return from(Manifest::new, metadataSupplier, filter, paths);
     }
 
     static SecureJar from(Supplier<Manifest> defaultManifest, Function<SecureJar, JarMetadata> metadataSupplier, final Path... paths) {

--- a/src/main/java/cpw/mods/jarhandling/SecureJar.java
+++ b/src/main/java/cpw/mods/jarhandling/SecureJar.java
@@ -13,13 +13,14 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
 public interface SecureJar {
     Path getPrimaryPath();
+
+    BiPredicate<String, String> getPathFilter();
 
     Optional<URI> findFile(String name);
 

--- a/src/main/java/cpw/mods/jarhandling/impl/Jar.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/Jar.java
@@ -56,11 +56,6 @@ public class Jar implements SecureJar {
     }
 
     @Override
-    public BiPredicate<String, String> getPathFilter() {
-        return filesystem.getFilesystemFilter();
-    }
-
-    @Override
     public Optional<URI> findFile(final String name) {
         var rel = filesystem.getPath(name);
         if (this.nameOverrides.containsKey(rel)) {

--- a/src/main/java/cpw/mods/jarhandling/impl/Jar.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/Jar.java
@@ -56,6 +56,11 @@ public class Jar implements SecureJar {
     }
 
     @Override
+    public BiPredicate<String, String> getPathFilter() {
+        return filesystem.getFilesystemFilter();
+    }
+
+    @Override
     public Optional<URI> findFile(final String name) {
         var rel = filesystem.getPath(name);
         if (this.nameOverrides.containsKey(rel)) {


### PR DESCRIPTION
This PR fixes module name generation so that instead of taking a substring before the first match of a `-version` identifier, it now replaces them all with an empty string so that extra suffixes and classifiers are included in the module name. This means we don't need to exclude native jars anymore and get ClassNotFoundExceptions. This PR also exposes the SecureJar's package filter as a method which is passed in from the constructor.