### PR TITLE
Only consider paths part of a Union FS if they actually exist.

### DIFF
--- a/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
+++ b/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
@@ -43,7 +43,9 @@ public class UnionFileSystem extends FileSystem {
         this.provider = provider;
         this.key = key;
         this.basepaths = IntStream.range(0, basepaths.length)
-                .mapToObj(i->basepaths[basepaths.length - i - 1]).toList(); // we flip the list so later elements are first in search order.
+                .mapToObj(i->basepaths[basepaths.length - i - 1])
+                .filter(Files::exists)
+                .toList(); // we flip the list so later elements are first in search order.
         this.embeddedFileSystems = this.basepaths.stream().filter(path -> !Files.isDirectory(path))
                 .map(UnionFileSystem::openFileSystem)
                 .flatMap(Optional::stream)


### PR DESCRIPTION
### General
This fixes an issue with the Union FS where when it builds it sources.
Due to it checking for `Files#isDirectory` being false for embedded filesystems a none existing file or directory is considered to be a zip.

### When does this happen:
- When an additional sourceset is added to a mod which has for example no resources added to it. The compiler will not generate the output directory but the run specification includes it anyway.

### How is this fixed:
- The `UnionFileSystem`'s constructor is adapted so that it checks the passed in basepaths for existence of the path passed in, causing none existing paths to be voided.