### PR TITLE
Better sanitization of module names & detect maven-like paths

### DIFF
--- a/src/main/java/cpw/mods/jarhandling/JarMetadata.java
+++ b/src/main/java/cpw/mods/jarhandling/JarMetadata.java
@@ -19,6 +19,8 @@ public interface JarMetadata {
     Pattern REPEATING_DOTS = Pattern.compile("(\\.)(\\1)+");
     Pattern LEADING_DOTS = Pattern.compile("^\\.");
     Pattern TRAILING_DOTS = Pattern.compile("\\.$");
+    // Extra sanitization
+    Pattern MODULE_VERSION = Pattern.compile("(?<=^|-)([\\d][.\\d]*)");
     Pattern NUMBERLIKE_PARTS = Pattern.compile("(?<=^|\\.)([0-9]+)"); // matches asdf.1.2b because both are invalid java identifiers
     List<String> ILLEGAL_KEYWORDS = List.of(
         "abstract","continue","for","new","switch","assert",
@@ -55,13 +57,13 @@ public interface JarMetadata {
         if (versionMaybe != null)
         {
             Path artifactMaybe = versionMaybe.getParent();
-            if (artifactMaybe != null && path.getFileName().toString().startsWith(artifactMaybe.getFileName() + "-"))
+            if (artifactMaybe != null && path.getFileName().toString().startsWith(artifactMaybe.getFileName().toString() + "-" + versionMaybe.getFileName().toString()))
             {
                 var name = artifactMaybe.getFileName().toString();
                 var ver = versionMaybe.getFileName().toString();
-                var mat = DASH_VERSION.matcher(ver);
+                var mat = MODULE_VERSION.matcher(ver);
                 if (mat.find()) {
-                    ver = ModuleDescriptor.Version.parse(ver.substring(mat.start() + 1)).toString();
+                    ver = ModuleDescriptor.Version.parse(ver.substring(mat.start())).toString();
                     return new SimpleJarMetadata(cleanModuleName(name), ver, pkgs, providers);
                 } else {
                     return new SimpleJarMetadata(cleanModuleName(name), null, pkgs, providers);

--- a/src/main/java/cpw/mods/jarhandling/JarMetadata.java
+++ b/src/main/java/cpw/mods/jarhandling/JarMetadata.java
@@ -19,7 +19,7 @@ public interface JarMetadata {
     Pattern REPEATING_DOTS = Pattern.compile("(\\.)(\\1)+");
     Pattern LEADING_DOTS = Pattern.compile("^\\.");
     Pattern TRAILING_DOTS = Pattern.compile("\\.$");
-    Pattern NUMBERLIKE_PARTS = Pattern.compile("(^|\\.)([0-9]+)"); // matches asdf.1.2b because both are invalid java identifiers
+    Pattern NUMBERLIKE_PARTS = Pattern.compile("(?<=^|\\.)([0-9]+)"); // matches asdf.1.2b because both are invalid java identifiers
     List<String> ILLEGAL_KEYWORDS = List.of(
         "abstract","continue","for","new","switch","assert",
         "default","goto","package","synchronized","boolean",
@@ -29,7 +29,7 @@ public interface JarMetadata {
         "extends","int","short","try","char","final","interface",
         "static","void","class","finally","long","strictfp",
         "volatile","const","float","native","super","while");
-    Pattern KEYWORD_PARTS = Pattern.compile("(^|\\.)(" + String.join("|", ILLEGAL_KEYWORDS) + ")(\\.|$)");
+    Pattern KEYWORD_PARTS = Pattern.compile("(?<=^|\\.)(" + String.join("|", ILLEGAL_KEYWORDS) + ")(?=\\.|$)");
 
     static JarMetadata from(final SecureJar jar, final Path... path) {
         if (path.length==0) throw new IllegalArgumentException("Need at least one path");
@@ -83,6 +83,7 @@ public interface JarMetadata {
     }
 
     private static String cleanModuleName(String mn) {
+
         // replace non-alphanumeric
         mn = NON_ALPHANUM.matcher(mn).replaceAll(".");
 
@@ -99,10 +100,10 @@ public interface JarMetadata {
             mn = TRAILING_DOTS.matcher(mn).replaceAll("");
 
         // fixup digits-only components
-        mn = NUMBERLIKE_PARTS.matcher(mn).replaceAll("$1_$2");
+        mn = NUMBERLIKE_PARTS.matcher(mn).replaceAll("_$1");
 
         // fixup keyword components
-        mn = KEYWORD_PARTS.matcher(mn).replaceAll("$1_$2$3");
+        mn = KEYWORD_PARTS.matcher(mn).replaceAll("_$1");
 
         return mn;
     }

--- a/src/test/java/cpw/mods/jarhandling/impl/TestMetadata.java
+++ b/src/test/java/cpw/mods/jarhandling/impl/TestMetadata.java
@@ -1,0 +1,21 @@
+package cpw.mods.jarhandling.impl;
+
+import cpw.mods.jarhandling.JarMetadata;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+
+public class TestMetadata
+{
+    @Test
+    void testDevMappedClass() throws MalformedURLException
+    {
+        var path = Paths.get("startofthepathchain/new-mod-1.16.5/1.1_mapped_official_1.17.1/new-mod-1.16.5-1.1_mapped_official_1.17.1.jar");
+        var meta = JarMetadata.fromFileName(path, new HashSet<>(), new ArrayList<>());
+        Assertions.assertEquals("_new.mod._1._16._5", meta.name());
+    }
+}

--- a/src/test/java/cpw/mods/jarhandling/impl/TestMetadata.java
+++ b/src/test/java/cpw/mods/jarhandling/impl/TestMetadata.java
@@ -11,18 +11,20 @@ import java.util.HashSet;
 public class TestMetadata
 {
     @Test
-    void testMavenLikeJar()
+    void testMavenJar()
     {
-        var path = Paths.get("startofthepathchain/new-protected-class-1.16.5/1.1_mapped_official_1.17.1/new-protected-class-1.16.5-1.1_mapped_official_1.17.1.jar");
+        var path = Paths.get("startofthepathchain/new-protected-class-1.16.5/1.1_mapped_official_1.17.1/new-protected-class-1.16.5-1.1_mapped_official_1.17.1-api.jar");
         var meta = JarMetadata.fromFileName(path, new HashSet<>(), new ArrayList<>());
         Assertions.assertEquals("_new._protected._class._1._16._5", meta.name());
+        Assertions.assertEquals("1.1_mapped_official_1.17.1", meta.version());
     }
 
     @Test
     void testNumberStart()
     {
-        var path = Paths.get("startofthepathchain/1life/1.5/1life-1.5.jar");
+        var path = Paths.get("mods/1life-1.5.jar");
         var meta = JarMetadata.fromFileName(path, new HashSet<>(), new ArrayList<>());
         Assertions.assertEquals("_1life", meta.name());
+        Assertions.assertEquals("1.5", meta.version());
     }
 }

--- a/src/test/java/cpw/mods/jarhandling/impl/TestMetadata.java
+++ b/src/test/java/cpw/mods/jarhandling/impl/TestMetadata.java
@@ -4,7 +4,6 @@ import cpw.mods.jarhandling.JarMetadata;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.net.MalformedURLException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -12,10 +11,18 @@ import java.util.HashSet;
 public class TestMetadata
 {
     @Test
-    void testDevMappedClass() throws MalformedURLException
+    void testMavenLikeJar()
     {
-        var path = Paths.get("startofthepathchain/new-mod-1.16.5/1.1_mapped_official_1.17.1/new-mod-1.16.5-1.1_mapped_official_1.17.1.jar");
+        var path = Paths.get("startofthepathchain/new-protected-class-1.16.5/1.1_mapped_official_1.17.1/new-protected-class-1.16.5-1.1_mapped_official_1.17.1.jar");
         var meta = JarMetadata.fromFileName(path, new HashSet<>(), new ArrayList<>());
-        Assertions.assertEquals("_new.mod._1._16._5", meta.name());
+        Assertions.assertEquals("_new._protected._class._1._16._5", meta.name());
+    }
+
+    @Test
+    void testNumberStart()
+    {
+        var path = Paths.get("startofthepathchain/1life/1.5/1life-1.5.jar");
+        var meta = JarMetadata.fromFileName(path, new HashSet<>(), new ArrayList<>());
+        Assertions.assertEquals("_1life", meta.name());
     }
 }


### PR DESCRIPTION
With this change, automatic module names will not error due to mod names like `new-something` or mods that have numbers at the satart of the mod name itself.
It also detects when jars are in a maven-like path hierarchy and uses the directory names for name and version.