### PR TITLE
Improve performance of building JarModuleFinder

### DIFF
--- a/src/main/java/cpw/mods/jarhandling/SecureJar.java
+++ b/src/main/java/cpw/mods/jarhandling/SecureJar.java
@@ -51,7 +51,7 @@ public interface SecureJar {
     }
 
     static SecureJar from(Supplier<Manifest> defaultManifest, Function<SecureJar, JarMetadata> metadataSupplier, final Path... paths) {
-        return from(defaultManifest, metadataSupplier, (e1, e2)->true, paths);
+        return from(defaultManifest, metadataSupplier, null, paths);
     }
 
     static SecureJar from(Supplier<Manifest> defaultManifest, Function<SecureJar, JarMetadata> metadataSupplier, BiPredicate<String, String> filter, final Path... paths) {
@@ -75,7 +75,7 @@ public interface SecureJar {
                 var entries = Files.readAllLines(path).stream()
                         .map(String::trim)
                         .filter(l->l.length() > 0 && !l.startsWith("#"))
-                        .filter(p->pkgFilter.test(p.replace('.','/'), ""))
+                        .filter(p-> pkgFilter == null || pkgFilter.test(p.replace('.','/'), ""))
                         .toList();
                 return new Provider(sname, entries);
             } catch (IOException e) {

--- a/src/main/java/cpw/mods/jarhandling/impl/Jar.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/Jar.java
@@ -216,9 +216,10 @@ public class Jar implements SecureJar {
     public Set<String> getPackages() {
         if (this.packages == null) {
             try (var walk = Files.walk(this.filesystem.getRoot())) {
-                this.packages = walk.filter(path -> Files.exists(path) && !Files.isDirectory(path))
+                this.packages = walk
                     .filter(path->!path.getName(0).toString().equals("META-INF"))
                     .filter(path->path.getFileName().toString().endsWith(".class"))
+                    .filter(Files::isRegularFile)
                     .map(path->path.subpath(0, path.getNameCount()-1))
                     .map(path->path.toString().replace('/','.'))
                     .filter(pkg->pkg.length()!=0)

--- a/src/main/java/cpw/mods/jarhandling/impl/Jar.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/Jar.java
@@ -61,7 +61,7 @@ public class Jar implements SecureJar {
         if (this.nameOverrides.containsKey(rel)) {
             rel = this.filesystem.getPath("META-INF", "versions", this.nameOverrides.get(rel).toString()).resolve(rel);
         }
-        return Optional.of(this.filesystem.getRoot().resolve(rel)).filter(UnionFileSystem::exists).map(Path::toUri);
+        return Optional.of(this.filesystem.getRoot().resolve(rel)).filter(Files::exists).map(Path::toUri);
     }
 
     private record StatusData(String name, Status status, CodeSigner[] signers) {

--- a/src/main/java/cpw/mods/jarhandling/impl/Jar.java
+++ b/src/main/java/cpw/mods/jarhandling/impl/Jar.java
@@ -61,7 +61,7 @@ public class Jar implements SecureJar {
         if (this.nameOverrides.containsKey(rel)) {
             rel = this.filesystem.getPath("META-INF", "versions", this.nameOverrides.get(rel).toString()).resolve(rel);
         }
-        return Optional.of(this.filesystem.getRoot().resolve(rel)).filter(Files::exists).map(Path::toUri);
+        return Optional.of(this.filesystem.getRoot().resolve(rel)).filter(UnionFileSystem::exists).map(Path::toUri);
     }
 
     private record StatusData(String name, Status status, CodeSigner[] signers) {

--- a/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
+++ b/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
@@ -186,6 +186,11 @@ public class UnionFileSystem extends FileSystem {
         }
     }
 
+    /**
+     * Checks if a file exists.
+     * Should return the same result as {@link Files#exists(Path, LinkOption...)}.
+     * This implementation should be faster for {@link UnionPath} paths as it does not use exceptions for code flow.
+     */
     public static boolean exists(final Path p) {
         if (p instanceof UnionPath unionPath) {
             return unionPath.getFileSystem().findFirstFiltered(unionPath).isPresent();

--- a/src/main/java/cpw/mods/niofs/union/UnionFileSystemProvider.java
+++ b/src/main/java/cpw/mods/niofs/union/UnionFileSystemProvider.java
@@ -93,9 +93,6 @@ public class UnionFileSystemProvider extends FileSystemProvider {
         if (filter == null && additional.isEmpty())
             throw new UnsupportedOperationException("Missing additional and/or filter");
 
-        if (filter == null)
-            filter = (p, b) -> true;
-
         var key = makeKey(path);
         try {
             return newFileSystemInternal(key, filter, Stream.concat(Stream.of(path), additional.stream()).toArray(Path[]::new));

--- a/src/test/java/cpw/mods/niofs/union/TestUnionFS.java
+++ b/src/test/java/cpw/mods/niofs/union/TestUnionFS.java
@@ -36,7 +36,7 @@ public class TestUnionFS {
         );
         var p = ufs.getRoot().resolve("subdir1/masktestd1.txt");
         p.subpath(2, 3);
-        var empty = new UnionPath(ufs);
+        var empty = new UnionPath(ufs, false);
     }
 
     @Test


### PR DESCRIPTION
The union FS is a bit slow currently.
The JarModuleFinder.of() call of the ModLauncher ModuleLayerHandler takes about 9 seconds on my machine in a forge dev environment, and most of this time is spend on getPackages, which iterates through the entire FileSystem.

By injecting the following code in JarModuleFinder.of(), the actual time needed can be profiled:
```java
        long start = System.currentTimeMillis();
        var moduleFinder = new JarModuleFinder(jars);
        long stop = System.currentTimeMillis();
        System.out.println("Creating " + JarModuleFinder.class.getSimpleName() + " for " + jars.length + " jars took " + (stop - start) + " ms!");
        return moduleFinder;
```
During startup in a development environment, this is called four times, and a quick VisualVM capture shows the longest run comes from `ModuleLayerHandler.buildLayer();`
Here are my timings without this patch:
```
Creating JarModuleFinder for 2 jars took 9263 ms!
Creating JarModuleFinder for 2 jars took 9351 ms!
Creating JarModuleFinder for 2 jars took 9243 ms!
```
I took the timings on my windows machine with the forge dev environment on my SSD.

Using VisualVM to identify hot spots, a few optimizations were made.
I tried to split them into indiviual commits, though some smaller ones are merged into one commit.
The improvments are considerable:
```
Creating JarModuleFinder for 2 jars took 2887 ms!
Creating JarModuleFinder for 2 jars took 2925 ms!
Creating JarModuleFinder for 2 jars took 2849 ms!
```
The time required to build the JarModuleFinder was reduced to about 1/3 of the original time required.