### PR TITLE
Minor fixes

### DIFF
--- a/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
+++ b/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
@@ -237,12 +237,13 @@ public class UnionFileSystem extends FileSystem {
             final var dir = toRealPath(bp, path);
             final var isSimple = embeddedFileSystems.containsKey(bp);
             if (dir == notExistingPath || !Files.exists(dir)) continue;
-            final var ds = Files.newDirectoryStream(dir, filter);
-            StreamSupport.stream(ds.spliterator(), false)
-                    .filter(p->testFilter(p, bp))
-                    .map(other -> (isSimple ? other : bp.relativize(other)).toString())
-                    .map(this::getPath)
-                    .forEachOrdered(allpaths::add);
+            try (var ds = Files.newDirectoryStream(dir, filter)) {
+                StreamSupport.stream(ds.spliterator(), false)
+                        .filter(p->testFilter(p, bp))
+                        .map(other -> (isSimple ? other : bp.relativize(other)).toString())
+                        .map(this::getPath)
+                        .forEachOrdered(allpaths::add);
+            }
         }
         return new DirectoryStream<>() {
             @Override

--- a/src/main/java/cpw/mods/niofs/union/UnionFileSystemProvider.java
+++ b/src/main/java/cpw/mods/niofs/union/UnionFileSystemProvider.java
@@ -141,9 +141,11 @@ public class UnionFileSystemProvider extends FileSystemProvider {
 
     @Override
     public FileSystem getFileSystem(final URI uri) {
-        var parts = uri.getPath().split("!");
-        if (!fileSystems.containsKey(parts[0])) throw new FileSystemNotFoundException();
-        return fileSystems.get(parts[0]);
+        synchronized (fileSystems) {
+            var parts = uri.getPath().split("!");
+            if (!fileSystems.containsKey(parts[0])) throw new FileSystemNotFoundException();
+            return fileSystems.get(parts[0]);
+        }
     }
 
     @Override


### PR DESCRIPTION
ece59acc1e6eab1beaefc7a4715b95cd2c4d787a: This is "nice to have" in general, and also fixes a strange SIGSEGV I have been running into when launching MC in dev.

4df082e6d384b329cdfa5e3c4930ee027cd094c5: Before only `put`/`remove` calls were synchronized, which prevented two simultaneous modifications, but not a modification during a read. If there are performance concerns about using a "general purpose" lock/mutex here I can replace it with a `ReadWriteLock`.