### PR TITLE
Close DirectoryStreams in UnionFileSystem

### DIFF
--- a/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
+++ b/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
@@ -237,12 +237,13 @@ public class UnionFileSystem extends FileSystem {
             final var dir = toRealPath(bp, path);
             if (dir == notExistingPath || !Files.exists(dir)) continue;
             final var isSimple = embeddedFileSystems.containsKey(bp);
-            final var ds = Files.newDirectoryStream(dir, filter);
-            StreamSupport.stream(ds.spliterator(), false)
-                    .filter(p->testFilter(p, bp))
-                    .map(other -> (isSimple ? other : bp.relativize(other)).toString())
-                    .map(this::getPath)
-                    .forEachOrdered(allpaths::add);
+            try (final var ds = Files.newDirectoryStream(dir, filter)) {
+                StreamSupport.stream(ds.spliterator(), false)
+                        .filter(p->testFilter(p, bp))
+                        .map(other -> (isSimple ? other : bp.relativize(other)).toString())
+                        .map(this::getPath)
+                        .forEachOrdered(allpaths::add);
+            }
         }
         return new DirectoryStream<>() {
             @Override


### PR DESCRIPTION
The resource leak caused by these for some reason causes strange segfaults on some Linux systems.
Examples:
For me (confirmed fixed by this):
https://gist.github.com/diesieben07/d268eb7c5974a5dae5ebbc07705f79aa

Someone on the forums:
https://forums.minecraftforge.net/topic/102976-117x-crash-when-trying-to-run-forge-forge-client/?tab=comments#comment-462085

This is a split-out version of one part of https://github.com/MinecraftForge/securejarhandler/pull/8.