### PR TITLE
Optimise path finding to remove the last exists test

### DIFF
--- a/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
+++ b/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
@@ -45,7 +45,6 @@ public class UnionFileSystem extends FileSystem {
     static final String SEP_STRING = "/";
 
 
-
     static {
         try {
             var hackfield = MethodHandles.Lookup.class.getDeclaredField("IMPL_LOOKUP");
@@ -69,8 +68,7 @@ public class UnionFileSystem extends FileSystem {
         try {
             var bytes = Files.readAllBytes(path);
             return new ByteArrayInputStream(bytes);
-        } catch (IOException ioe)
-        {
+        } catch (IOException ioe) {
             throw new UncheckedIOException(ioe);
         }
     }
@@ -79,6 +77,7 @@ public class UnionFileSystem extends FileSystem {
         public NoSuchFileException(final String file) {
             super(file);
         }
+
         @Override
         public synchronized Throwable fillInStackTrace() {
             return this;
@@ -95,6 +94,7 @@ public class UnionFileSystem extends FileSystem {
             return this;
         }
     }
+
     private final UnionPath root = new UnionPath(this, "/");
     private final UnionPath notExistingPath = new UnionPath(this, "/SNOWMAN");
     private final UnionFileSystemProvider provider;
@@ -102,28 +102,29 @@ public class UnionFileSystem extends FileSystem {
     private final List<Path> basepaths;
     private final int lastElementIndex;
     private final BiPredicate<String, String> pathFilter;
-    private final Map<Path,EmbeddedFileSystemMetadata> embeddedFileSystems;
+    private final Map<Path, EmbeddedFileSystemMetadata> embeddedFileSystems;
 
     public Path getPrimaryPath() {
-        return basepaths.get(basepaths.size()-1);
+        return basepaths.get(basepaths.size() - 1);
     }
 
     public BiPredicate<String, String> getFilesystemFilter() {
         return pathFilter;
     }
 
-    String getKey()  {
+    String getKey() {
         return this.key;
     }
 
-    private record EmbeddedFileSystemMetadata(Path path, FileSystem fs, SeekableByteChannel fsCh) {}
+    private record EmbeddedFileSystemMetadata(Path path, FileSystem fs, SeekableByteChannel fsCh) {
+    }
 
     public UnionFileSystem(final UnionFileSystemProvider provider, final BiPredicate<String, String> pathFilter, final String key, final Path... basepaths) {
         this.pathFilter = pathFilter;
         this.provider = provider;
         this.key = key;
         this.basepaths = IntStream.range(0, basepaths.length)
-                .mapToObj(i->basepaths[basepaths.length - i - 1])
+                .mapToObj(i -> basepaths[basepaths.length - i - 1])
                 .filter(Files::exists)
                 .toList(); // we flip the list so later elements are first in search order.
         lastElementIndex = basepaths.length - 1;
@@ -242,24 +243,36 @@ public class UnionFileSystem extends FileSystem {
 
     private Optional<Path> findFirstPathAt(final UnionPath path) {
         return this.basepaths.stream()
-                .map(p->toRealPath(p , path))
-                .filter(p->p!=notExistingPath)
+                .map(p -> toRealPath(p, path))
+                .filter(p -> p != notExistingPath)
                 .filter(Files::exists)
                 .findFirst();
     }
 
     private static boolean zipFsExists(UnionFileSystem ufs, Path path) {
         try {
-            if (Optional.ofNullable(ufs.embeddedFileSystems.get(path.getFileSystem())).filter(efs->!efs.fsCh.isOpen()).isPresent()) throw new IllegalStateException("The zip file has closed!");
+            if (Optional.ofNullable(ufs.embeddedFileSystems.get(path.getFileSystem())).filter(efs -> !efs.fsCh.isOpen()).isPresent())
+                throw new IllegalStateException("The zip file has closed!");
             return (boolean) ZIPFS_EXISTS.invoke(path);
         } catch (Throwable t) {
             throw new IllegalStateException(t);
         }
     }
-    private Optional<Path> findFirstFiltered(final UnionPath path) {
+
+    /**
+     * Finds the first real {@link Path} that matches the {@link UnionPath#toString() path} of the given {@code unionPath}, and the {@link #pathFilter filter}
+     * of the file system.
+     *
+     * @param unionPath the path to find
+     * @return an optional containing the first real path that {@link Files#exists(Path, LinkOption...) exists},
+     * or otherwise the last path, if this file system has at least one {@link #basepaths base path}
+     */
+    private Optional<Path> findFirstFiltered(final UnionPath unionPath) {
+        // Iterate the first base paths to try to find matching existing files
         for (int i = 0; i < lastElementIndex; i++) {
             final Path p = this.basepaths.get(i);
-            final Path realPath = toRealPath(p, path);
+            final Path realPath = toRealPath(p, unionPath);
+            // Test if the real path exists and matches the filter of this file system
             if (realPath != notExistingPath && testFilter(realPath, p)) {
                 if (realPath.getFileSystem() == FileSystems.getDefault()) {
                     if (realPath.toFile().exists()) {
@@ -275,9 +288,11 @@ public class UnionFileSystem extends FileSystem {
             }
         }
 
+        // Otherwise, if we still haven't found an existing path, return the last possibility without checking its existence
         if (lastElementIndex >= 0) {
             final Path last = basepaths.get(lastElementIndex);
-            final Path realPath = toRealPath(last, path);
+            final Path realPath = toRealPath(last, unionPath);
+            // We still care about the FS filter, but not about the existence of the real path
             if (realPath != notExistingPath && testFilter(realPath, last)) {
                 return Optional.of(realPath);
             }
@@ -286,7 +301,7 @@ public class UnionFileSystem extends FileSystem {
         return Optional.empty();
     }
 
-    private <T> Stream<T> streamPathList(final Function<Path,Optional<T>> function) {
+    private <T> Stream<T> streamPathList(final Function<Path, Optional<T>> function) {
         return this.basepaths.stream()
                 .map(function)
                 .flatMap(Optional::stream);
@@ -301,7 +316,7 @@ public class UnionFileSystem extends FileSystem {
                 Path realPath = toRealPath(base, path);
                 if (realPath != notExistingPath) {
                     Optional<BasicFileAttributes> fileAttributes = this.getFileAttributes(realPath);
-                        if (fileAttributes.isPresent() && testFilter(realPath, base)) {
+                    if (fileAttributes.isPresent() && testFilter(realPath, base)) {
                         return (A) fileAttributes.get();
                     }
                 }
@@ -314,7 +329,7 @@ public class UnionFileSystem extends FileSystem {
 
     public void checkAccess(final UnionPath p, final AccessMode... modes) throws IOException {
         try {
-            findFirstFiltered(p).ifPresentOrElse(path-> {
+            findFirstFiltered(p).ifPresentOrElse(path -> {
                 try {
                     if (modes.length == 0) {
                         if (path.getFileSystem() == FileSystems.getDefault()) {
@@ -332,7 +347,7 @@ public class UnionFileSystem extends FileSystem {
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }
-            }, ()->{
+            }, () -> {
                 throw new UncheckedIOException(new NoSuchFileException(p.toString()));
             });
         } catch (UncheckedIOException e) {
@@ -385,7 +400,7 @@ public class UnionFileSystem extends FileSystem {
             final var isSimple = embeddedFileSystems.containsKey(bp);
             try (final var ds = Files.newDirectoryStream(dir, filter)) {
                 StreamSupport.stream(ds.spliterator(), false)
-                        .filter(p->testFilter(p, bp))
+                        .filter(p -> testFilter(p, bp))
                         .map(other -> StreamSupport.stream(Spliterators.spliteratorUnknownSize((isSimple ? other : bp.relativize(other)).iterator(), Spliterator.ORDERED), false)
                                 .map(Path::getFileName).map(Path::toString).toArray(String[]::new))
                         .map(this::fastPath)


### PR DESCRIPTION
`UnionFileSystem#findFirstFiltered` will currently check if a file exists for every merged path. This is a bit inefficient since this causes possibly unneeded existence checks, that can in some cases be heavy (for example, native checks on Windows for files on the C drive).
This PR makes `findFirstFiltered` not check for the existence of the last path, and simply return it if all previous paths did not exist. As in all cases where the method is used, if the optional is empty a `NoSuchFileException` will be raised (intentionally), this is a safe change to make.

[Benchmark](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/Matyrobbrt/b8d3d255cc2b02dafc453976dc5fbffb/raw/f2f330ceb22d1a36617db022aa0c3fdad7b43e39/pre.json,https://gist.githubusercontent.com/Matyrobbrt/b8d3d255cc2b02dafc453976dc5fbffb/raw/f2f330ceb22d1a36617db022aa0c3fdad7b43e39/post4.json); the declines can be safely considered [error margin](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/Matyrobbrt/b8d3d255cc2b02dafc453976dc5fbffb/raw/ec47dcf05e9d7c0bc370373cd698b6bea3400739/pre.json,https://gist.githubusercontent.com/Matyrobbrt/b8d3d255cc2b02dafc453976dc5fbffb/raw/ec47dcf05e9d7c0bc370373cd698b6bea3400739/postv3.json).