### PR TITLE
SJH 3.0: Replace BiPredicate by UnionPathFilter in UnionFS and hide SecureJar impl details

### DIFF
--- a/src/main/java/cpw/mods/jarhandling/JarContentsBuilder.java
+++ b/src/main/java/cpw/mods/jarhandling/JarContentsBuilder.java
@@ -53,6 +53,6 @@ public final class JarContentsBuilder {
      * Builds the jar.
      */
     public JarContents build() {
-        return new JarContentsImpl(paths, defaultManifest, pathFilter == null ? null : pathFilter::test);
+        return new JarContentsImpl(paths, defaultManifest, pathFilter);
     }
 }

--- a/src/main/java/cpw/mods/jarhandling/SecureJar.java
+++ b/src/main/java/cpw/mods/jarhandling/SecureJar.java
@@ -138,7 +138,7 @@ public interface SecureJar {
         /**
          * Helper method to parse service provider implementations from a {@link Path}.
          */
-        public static Provider fromPath(final Path path, final UnionPathFilter pkgFilter) {
+        public static Provider fromPath(Path path, @Nullable UnionPathFilter pkgFilter) {
             final var sname = path.getFileName().toString();
             try {
                 var entries = Files.readAllLines(path).stream()

--- a/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
+++ b/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java
@@ -31,12 +31,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+/**
+ * Can be instantiated using the public methods in {@link UnionFileSystemProvider}.
+ */
 public class UnionFileSystem extends FileSystem {
     private static final MethodHandle ZIPFS_CH;
     private static final MethodHandle FCI_UNINTERUPTIBLE;
@@ -83,7 +88,7 @@ public class UnionFileSystem extends FileSystem {
         public UncheckedIOException(final IOException cause) {
             super(cause);
         }
-        
+
         public UncheckedIOException(final String message, final IOException cause) {
             super(message, cause);
         }
@@ -107,6 +112,9 @@ public class UnionFileSystem extends FileSystem {
         return basepaths.get(basepaths.size() - 1);
     }
 
+    /**
+     * {@return the filter for this file system, or null if there is none}
+     */
     @Nullable
     public UnionPathFilter getFilesystemFilter() {
         return pathFilter;
@@ -119,7 +127,7 @@ public class UnionFileSystem extends FileSystem {
     private record EmbeddedFileSystemMetadata(Path path, FileSystem fs, SeekableByteChannel fsCh) {
     }
 
-    public UnionFileSystem(final UnionFileSystemProvider provider, @Nullable UnionPathFilter pathFilter, final String key, final Path... basepaths) {
+    UnionFileSystem(UnionFileSystemProvider provider, @Nullable UnionPathFilter pathFilter, String key, Path... basepaths) {
         this.pathFilter = pathFilter;
         this.provider = provider;
         this.key = key;

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -3,7 +3,6 @@ import cpw.mods.niofs.union.UnionFileSystemProvider;
 
 module cpw.mods.securejarhandler {
     exports cpw.mods.jarhandling;
-    exports cpw.mods.jarhandling.impl; // TODO - Bump version, and remove this export, you don't need our implementation
     exports cpw.mods.cl;
     exports cpw.mods.niofs.union;
     requires jdk.unsupported;


### PR DESCRIPTION
Two breaking changes:
- `UnionPathFilter` was introduced in #47 for `JarContentsBuilder`. This PR replaces the remaining uses of the `BiPredicate<String, String>`. (Except for the `SecureJar.from` overloads because they don't hurt to keep - and FML is still using them).
- Stop exporting the `cpw.mods.jarhandling.impl` package - its impl details should not be exposed to the outside world.

**This is a breaking change and needs to be merged manually to apply the `3.0` tag.**

**Tested on ATM9 and it still works - this is not actually a breaking change for our usage in NeoForge.**