### PR TITLE
Allow ModuleClassLoader to optionally delegate class-loading to parent

### DIFF
--- a/src/main/java/cpw/mods/cl/ModuleClassLoader.java
+++ b/src/main/java/cpw/mods/cl/ModuleClassLoader.java
@@ -76,11 +76,11 @@ public class ModuleClassLoader extends ClassLoader {
      * This constructor allows setting the parent {@linkplain ClassLoader classloader}. Use this with caution since
      * it will allow loading of classes from the classpath directly if the {@linkplain ClassLoader#getSystemClassLoader() system classloader}
      * is reachable from the given parent classloader.
-     * <p/>
+     * <p>
      * Generally classes that are in packages covered by reachable modules are preferably loaded from these modules.
      * If a class-path entry is not shadowed by a module, specifying a parent class-loader may lead to those
      * classes now being loadable instead of throwing a {@link ClassNotFoundException}.
-     * <p/>
+     * <p>
      * This relaxed classloader isolation is used in unit-testing, where testing libraries are loaded on the
      * system class-loader outside our control (by the Gradle test runner). We must not reload these classes
      * inside the module layers again, otherwise tests throw incompatible exceptions or may not be found at all.


### PR DESCRIPTION
The goal is to add a new entrypoint to https://github.com/McModLauncher/bootstraplauncher for JUnit runners, which disables classloader isolation. This change adds the needed constructor to ModuleClassLoader to enable that.

This is used to allow test-classes to live in the GAME layer, while still loading JUnit and  other testing library classes found on the normal classpath. When being run by a unit testing framework, we do **not** control the JVM entrypoint like we normally do, and Gradle for example will class-load JUnit before calling any other hook. Our test classes need to refer to those same loaded classes, making it easier if isolation is disabled in such scenarios.
