### PR TITLE
Always load UnionURLStreamHandler even in non-modular environments

### DIFF
--- a/src/main/java/cpw/mods/cl/ModularURLHandler.java
+++ b/src/main/java/cpw/mods/cl/ModularURLHandler.java
@@ -7,24 +7,36 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public class ModularURLHandler implements URLStreamHandlerFactory {
     public static final ModularURLHandler INSTANCE = new ModularURLHandler();
     private Map<String, IURLProvider> handlers;
 
     public static void initFrom(ModuleLayer layer) {
+        var handlers = new HashMap<String, IURLProvider>();
+
+        // This handler is required for SJH to work.
+        var unionHandler = new UnionURLStreamHandler();
+        handlers.put(unionHandler.protocol(), unionHandler);
+
         if (layer == null) {
-            INSTANCE.handlers = null;
-        } else {
-            INSTANCE.handlers = ServiceLoader.load(layer, IURLProvider.class).stream()
+            // Support non-modular environment for testing purposes
+            ServiceLoader.load(IURLProvider.class).stream()
                     .map(ServiceLoader.Provider::get)
-                    .collect(Collectors.toMap(IURLProvider::protocol, Function.identity()));
+                    .forEach(handler -> handlers.putIfAbsent(handler.protocol(), handler));
+        } else {
+            ServiceLoader.load(layer, IURLProvider.class).stream()
+                    .map(ServiceLoader.Provider::get)
+                    .forEach(handler -> handlers.putIfAbsent(handler.protocol(), handler));
         }
+
+        INSTANCE.handlers = Map.copyOf(handlers);
     }
+
     @Override
     public URLStreamHandler createURLStreamHandler(final String protocol) {
         if (handlers == null) return null;

--- a/src/main/java/cpw/mods/cl/ModularURLHandler.java
+++ b/src/main/java/cpw/mods/cl/ModularURLHandler.java
@@ -1,5 +1,7 @@
 package cpw.mods.cl;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -16,7 +18,7 @@ public class ModularURLHandler implements URLStreamHandlerFactory {
     public static final ModularURLHandler INSTANCE = new ModularURLHandler();
     private Map<String, IURLProvider> handlers;
 
-    public static void initFrom(ModuleLayer layer) {
+    public static void initFrom(@Nullable ModuleLayer layer) {
         var handlers = new HashMap<String, IURLProvider>();
 
         // This handler is required for SJH to work.

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,5 +1,4 @@
 import cpw.mods.cl.ModularURLHandler;
-import cpw.mods.cl.UnionURLStreamHandler;
 import cpw.mods.niofs.union.UnionFileSystemProvider;
 
 module cpw.mods.securejarhandler {
@@ -14,5 +13,4 @@ module cpw.mods.securejarhandler {
     requires static org.jetbrains.annotations;
     provides java.nio.file.spi.FileSystemProvider with UnionFileSystemProvider;
     uses cpw.mods.cl.ModularURLHandler.IURLProvider;
-    provides ModularURLHandler.IURLProvider with UnionURLStreamHandler;
 }


### PR DESCRIPTION
The use case for this is the use of SJH inside of FML unit tests where SJH itself was not loaded as a module.

It is perfectly capable of being used, but fails due to the `union` protocol handler not being loaded. This change makes SJH always load its own protocol handler regardless of layer and supports the extension point in non modular environments too.

As an aside: The extension point does not seem to be used by anyone else according to a GH search and can likely be deprecated/removed at some point.